### PR TITLE
Add Phan to static analysers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Do you miss a project, tool or article, that you consider useful to the broader 
 ### Analyzing
 
 * https://github.com/phpstan/phpstan - PHP Static Analysis Tool based on php-parser
+* https://github.com/phan/phan - PHP Static Analysis Tool based on the php-ast extension 
 * https://leanpub.com/recipes-for-decoupling - Book about PHPStan & AST-based analysis
 
 ### Modifying


### PR DESCRIPTION
Just another static analyser, but this one uses the php-ast extension instead of PHP-Parser.