### PR TITLE
Add phpstan-doctrine

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Do you miss a project, tool or article, that you consider useful to the broader 
 ## Databases
 
 * https://github.com/staabm/phpstan-dba - PHPStan static analysis and type inference for the database access layer
+* https://github.com/phpstan/phpstan-doctrine - PHPStan static analysis and type inference for Doctrine ORM
 * https://github.com/phpmyadmin/sql-parser - A validating SQL lexer and parser with a focus on MySQL dialect
 
 <br>


### PR DESCRIPTION
phpstan-doctrine is a PHPStan plugin for Doctrine ORM. Among other things, it can analyse and infer the type of DQL queries statically.

There are a few examples on the README: https://github.com/phpstan/phpstan-doctrine#query-type-inference

_DQL_ is the Doctrine ORM language for querying persisted objects. It ressembles SQL, but it's not really SQL. It falls in the databases section, though.

phpstan-doctrine can analyse DQL queries by leveraging a DQL parser, an AST walker, and entity metadata. It accurately infers the type that will be returned by DQL queries, regardless of the complexity of the query.

It's related to phpstan-dba, but there is no overlap in features. phpstan-dba is for SQL and can't analyze DQL, while phpstan-doctrine is for DQL and can't analyze SQL.